### PR TITLE
Draw box to cover left part of title page

### DIFF
--- a/beamerinnerthemerli.sty
+++ b/beamerinnerthemerli.sty
@@ -61,6 +61,7 @@
   \filldraw[draw=white,fill=white] (w2tR) -- (bgS) -- ($ (bgS) + ({-2*\halfWidthBar},0) $) -- ($ (w2tR) + ({-2*\halfWidthBar},0) $) -- cycle;
   \filldraw[draw=white,fill=white] (picUpN) -- (w1tR) -- (paperTR) -- (bgN) -- (bgW) -- (picUpS) -- (picUpE) -- cycle;
   \filldraw[draw=none,fill=rligraylight] (bgS) -- (bgW) -- (bgN) -- (paperBR) -- cycle;
+  \filldraw[draw=white,fill=white] (paperBL) -- (w1bL) -- (w1tL) -- (paperTL) -- cycle;
   
   \draw (1,0.685\paperheight) -- (0.5\textwidth,0.685\paperheight);
   


### PR DESCRIPTION
Sometimes, when the title background image is too large, it appears on the left side of the title page and messes with the text there. To see what I mean, you can take the dev and increase the size of the background image to 2x /textsize. To prevent the image from appearing on the left, I added a white box with tikz which hides it, similar to the triangles. 

Issue #17 will still remain.